### PR TITLE
Add re-render upon merging to main

### DIFF
--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -11,7 +11,7 @@ on:
   - cron: "0 3 * * *"
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-collection:

--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   schedule:
   - cron: "0 3 * * *"
+  push:
+    branches:
+      - master
 
 jobs:
   build-collection:
@@ -19,7 +22,7 @@ jobs:
       repository: $GITHUB_REPOSITORY
     secrets:
       gh_pat: ${{ secrets.GH_PAT }}
-  
+
   render-main:
     runs-on: ubuntu-latest
           # install.packages("remotes") # in case we decide not to go with the container...


### PR DESCRIPTION
Just a simple add to the render-html trigger so that it not only runs at 3am but also runs whenever we make changes to this repository by merging to main. 