### PR TITLE
Test ottrpal revert

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -133,7 +133,7 @@ jobs:
       # This job creates a shared scaffold for both.
       - name: Run TOC-less version of render
         id: tocless
-        run: Rscript -e "devtools::install_github('jhudsl/ottrpal', upgrade = 'never'); ottrpal::render_without_toc()"
+        run: Rscript -e "devtools::install_github('jhudsl/ottrpal', ref = remotes::github_pull('133'), upgrade = 'never'); ottrpal::render_without_toc()"
         env:
           GITHUB_PAT: ${{ secrets.gh_pat }}
 


### PR DESCRIPTION
Paired with https://github.com/jhudsl/ottrpal/pull/133

Want to remove this import statement from `ottrpal` since it appears to not be doing anything. But confirming here that it doesn't break things since this is why it was added originally.

Relevant:
https://github.com/jhudsl/ottrpal/commit/11ebd50610c4488a26d8e2cb4b9c4a57dcd4fdf3#commitcomment-143068596