### PR TITLE
Update pull_request.yml

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,6 +80,7 @@ jobs:
     with:
       check_type: spelling
       error_min: 3
+    secrets:
       gh_pat: ${{ secrets.GH_PAT }}
 
   url-check:
@@ -90,6 +91,7 @@ jobs:
     with:
       check_type: urls
       error_min: 0
+    secrets:
       gh_pat: ${{ secrets.GH_PAT }}
       
   render-preview:

--- a/FAQ.Rmd
+++ b/FAQ.Rmd
@@ -9,7 +9,7 @@ DaSL Collection uses the GitHub API to gather repositories that we have worked o
 The following are needed to list your repository in the collection:
 
 - Your repository must be created under the `jhudsl` or `fhdsl` organizations. For repositories under other organizations, you can fork the repository into the `jhudsl` or `fhdsl` organizations. [Example](https://github.com/fhdsl/Data-Wrangling)
-- Your repository "code" tab must have a **description**, **homepage**, and **topic tags** filled out in the "About" section on the righthand side. 
+- Your repository "code" tab must have a **description**, **homepage**, and **topic tags** filled out in the "About" section on the right-hand side. 
 - Your repository must be set to **public**.
 - Your repository must have at least one of three tags: `course` (general purpose courses), `hutch-course` (Fred Hutch specific courses), or `edtech-software`. If you feel there is another applicable category that should be listed, please reach out to [Ava](https://github.com/avahoffman).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DaSL Collection uses the GitHub API to gather jhudsl and fhdsl organization repo
 The Collection only includes repositories that meet the following criteria. Repositories must:
 
 - be created under the `jhudsl` or `fhdsl` organizations
-- have **description**, **homepage**, and **topic tags** filled out in the "About" section on the righthand side
+- have **description**, **homepage**, and **topic tags** filled out in the "About" section on the right-hand side
 - be set to **public**
 - have at least one of three tags: `course` (general purpose courses), `hutch-course` (Fred Hutch specific courses), `edtech-software`
 


### PR DESCRIPTION
indicating secretes in pull_request.yml in a more consistent way

Had an error about this and some of the later mentions of the secrets were not recognized, using what was used earlier instead

https://github.com/fhdsl/DaSL_Collection/actions/runs/14842772531

[Invalid workflow file: .github/workflows/pull_request.yml#L83](https://github.com/fhdsl/DaSL_Collection/actions/runs/14842772531/workflow)
The workflow is not valid. .github/workflows/pull_request.yml (Line: 83, Col: 15): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GH_PAT .github/workflows/pull_request.yml (Line: 93, Col: 15): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GH_PAT