### PR TITLE
adding dispatch option for rendering build-collection

### DIFF
--- a/.github/workflows/build-collection.yml
+++ b/.github/workflows/build-collection.yml
@@ -2,6 +2,7 @@
 name: Build Collection
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       render-type:


### PR DESCRIPTION
I noticed that the https://github.com/fhdsl/DaSL_Collection/actions/workflows/build-collection.yml has never run. The plan I think was to be triggered by the other workflows, but I may be misinterpreting.

I am adding a dispatch option in case we want to manually trigger (this is helpful for testing changes in the collection or the code to generate the collection). I wonder if a schedule makes  sense for this workflow too (like the render wokflow). 